### PR TITLE
Stop soil resetting when plant it above

### DIFF
--- a/soil.lua
+++ b/soil.lua
@@ -60,7 +60,7 @@ minetest.register_abm({
 		elseif node.name == "farming:soil_wet" then
 			minetest.set_node(pos, {name = "farming:soil"})
 
-		elseif node.name == "farming:soil" then
+		elseif node.name == "farming:soil" and minetest.get_item_group(nn, "plant") == 0 then
 			minetest.set_node(pos, {name = "default:dirt"})
 		end
 	end,


### PR DESCRIPTION
I figured based on this comment "if solid/not plant change soil to dirt", the soil shouldn't reset (even if dry) if there is a plant on it, this should fix the issue.